### PR TITLE
Fix: AotA plutonium import typos fix

### DIFF
--- a/book/Monte Cook; Arcana of the Ancients.json
+++ b/book/Monte Cook; Arcana of the Ancients.json
@@ -4939,7 +4939,7 @@
 					"{@item Emotion smoother|AotA}"
 				],
 				[
-					"35 Fa",
+					"35",
 					"{@item Farspeaker|AotA}"
 				],
 				[
@@ -8854,7 +8854,7 @@
 					{
 						"type": "entries",
 						"entries": [
-							"Culovas are {@spidery humanoids|Culovas might be a mutant offshoot of a creature like an ettercap, or ettercaps might be near- humanoid mutations of ancient culovas.} with eight spindly legs, a bulbous midsection, and a pair of human-like arms with three fingers. Eight eyes adorn their heads like colored beads above disturbingly broad, toothy mouths. They move with astonishing quickness.",
+							"Culovas are {@footnote spidery humanoids|Culovas might be a mutant offshoot of a creature like an ettercap, or ettercaps might be near- humanoid mutations of ancient culovas.} with eight spindly legs, a bulbous midsection, and a pair of human-like arms with three fingers. Eight eyes adorn their heads like colored beads above disturbingly broad, toothy mouths. They move with astonishing quickness.",
 							{
 								"type": "entries",
 								"name": "Forest Hunters",
@@ -12777,7 +12777,7 @@
 					{
 						"type": "entries",
 						"entries": [
-							"The sound of sandpaper on sandpaper scratches the air when a kanthid moves. Most kanthids are multilimbed creatures shaped vaguely like other beasts and creatures. {@footone Whatever its underlying shape|Breaking open a defeated kanthid reveals it to be a composite creature made of hundreds of smaller \"polyps\" (essentially, tentacles surrounding a mouth and digestive sac protected by a mineral encrustation) built on the skeleton of a dead animal}, the rough skin of a kanthid is a stony mineral whorled and studded with short spines. Here and there, openings in the stone reveal mouths ringed in writhing cilia.",
+							"The sound of sandpaper on sandpaper scratches the air when a kanthid moves. Most kanthids are multilimbed creatures shaped vaguely like other beasts and creatures. {@footnote Whatever its underlying shape|Breaking open a defeated kanthid reveals it to be a composite creature made of hundreds of smaller \"polyps\" (essentially, tentacles surrounding a mouth and digestive sac protected by a mineral encrustation) built on the skeleton of a dead animal}, the rough skin of a kanthid is a stony mineral whorled and studded with short spines. Here and there, openings in the stone reveal mouths ringed in writhing cilia.",
 							{
 								"type": "entries",
 								"name": "Speech Mimickers",
@@ -14523,7 +14523,7 @@
 								"type": "entries",
 								"name": "",
 								"entries": [
-									"Neveri were secured by the Ancients in various forgotten prisons. But why? Why didn't the Ancients simply destroy the neveri? Many possibilities suggest themselves, but the plainest answer might be because {@footonte even the Ancients could not devise a method to kill them.|The only way to stop a neveri is by confining it or shunting it into an ultimate region of destruction, such as the sun}",
+									"Neveri were secured by the Ancients in various forgotten prisons. But why? Why didn't the Ancients simply destroy the neveri? Many possibilities suggest themselves, but the plainest answer might be because {@footnote even the Ancients could not devise a method to kill them.|The only way to stop a neveri is by confining it or shunting it into an ultimate region of destruction, such as the sun}",
 									"Thankfully extremely rare, neveri apparently spend years at a time either inactive or imprisoned from some earlier epoch. When one becomes active (or escapes), it makes a lair in a hard-to-reach location within a day or two of a large population of living things and sets to work feeding its ravenous appetite."
 								]
 							},


### PR DESCRIPTION
Typos that broke plutonium imports for some cretures and tables. Pointed by @ Jaguar on discord